### PR TITLE
Bugfix React 15.5+ PropTypes

### DIFF
--- a/WheelCurvedPicker.android.js
+++ b/WheelCurvedPicker.android.js
@@ -1,6 +1,8 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types'
+
 import {
 	View,
 	ColorPropType,
@@ -10,43 +12,55 @@ import _ from 'lodash';
 
 
 const defaultItemStyle = { color: 'white', fontSize: 26 };
-const WheelCurvedPicker = React.createClass ({
-
+const WheelCurvedPickerNativeInterface = {
+	name: 'WheelCurvedPicker',
 	propTypes: {
 		...View.propTypes,
-
-		data: React.PropTypes.array,
-
+		data:PropTypes.array,
 		textColor: ColorPropType,
+		textSize: PropTypes.number,
+		itemStyle: PropTypes.object,		
+		itemSpace: PropTypes.number,
+		onValueChange: PropTypes.func,		
+		selectedValue: PropTypes.any,
+		selectedIndex: PropTypes.number,
+	}
+}
 
-		textSize: React.PropTypes.number,
+const WheelCurvedPickerNative = requireNativeComponent('WheelCurvedPicker', WheelCurvedPickerNativeInterface);
 
-		itemStyle: React.PropTypes.object,
+class WheelCurvedPicker extends React.Component {
+	static propTypes = {
+		...View.propTypes,
+		data:PropTypes.array,
+		textColor: ColorPropType,
+		textSize: PropTypes.number,
+		itemStyle: PropTypes.object,		
+		itemSpace: PropTypes.number,
+		onValueChange: PropTypes.func,		
+		selectedValue: PropTypes.any,
+		selectedIndex: PropTypes.number,
+	}
 
-		itemSpace: React.PropTypes.number,
-
-		onValueChange: React.PropTypes.func,
-
-		selectedValue: React.PropTypes.any,
-
-		selectedIndex: React.PropTypes.number,
-	},
-
-	getDefaultProps(): Object {
+	constructor(props){
+		super(props)
+		this.state = this._stateFromProps(props)
+	}
+	getDefaultProps() {
 		return {
 			itemSpace: 20
-		};
-	},
+		}
+	}
 
-	getInitialState: function() {
+	getInitialState() {
 		return this._stateFromProps(this.props);
-	},
+	}
 
-	componentWillReceiveProps: function(nextProps) {
-		this.setState(this._stateFromProps(nextProps));
-	},
+	componentWillReceiveProps (props) {
+		this.setState(this._stateFromProps(props));
+	}
 
-	_stateFromProps: function(props) {
+	_stateFromProps(props) {
 		let selectedIndex = 0;
 		let items = [];
 		React.Children.forEach(props.children, function (child, index) {
@@ -61,37 +75,39 @@ const WheelCurvedPicker = React.createClass ({
 		let textColor =itemStyle.color
 
 		return {selectedIndex, items, textSize, textColor};
-	},
+	}
 
-	_onValueChange: function(e: Event) {
+	_onValueChange(e) {
 		if (this.props.onValueChange) {
 			this.props.onValueChange(e.nativeEvent.data);
 		}
-	},
+	}
 
 	render() {
 		return <WheelCurvedPickerNative
 				{...this.props}
-				onValueChange={this._onValueChange}
+				onValueChange={(e)=>{
+					this._onValueChange(e)
+				} }
 				data={this.state.items}
 				textColor={this.state.textColor}
 				textSize={this.state.textSize}
 				selectedIndex={parseInt(this.state.selectedIndex)} />;
 	}
-});
+}
 
-WheelCurvedPicker.Item = React.createClass({
-	propTypes: {
-		value: React.PropTypes.any, // string or integer basically
-		label: React.PropTypes.string,
-	},
+class Item extends React.Component {
+	static propTypes = {
+		value: PropTypes.any, // string or integer basically
+		label: PropTypes.string,
+	}
 
-	render: function() {
+	render() {
 		// These items don't get rendered directly.
-		return null;
-	},
-});
+		return null
+	}
+}
 
-const WheelCurvedPickerNative = requireNativeComponent('WheelCurvedPicker', WheelCurvedPicker);
+WheelCurvedPicker.Item = Item;
 
-module.exports = WheelCurvedPicker;
+export default WheelCurvedPicker

--- a/date-picker.android.js
+++ b/date-picker.android.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { View } from 'react-native'
 import Picker from './picker'
 import moment from 'moment'
@@ -45,18 +46,20 @@ export default class DatePicker extends Component {
       return { value: n + 1, label: `${n + 1}${this.props.labelUnit.month}` }
     })
   }
+  
   static propTypes = {
-    labelUnit: React.PropTypes.shape({
-      year: React.PropTypes.string,
-      month: React.PropTypes.string,
-      day: React.PropTypes.string
+    labelUnit: PropTypes.shape({
+      year: PropTypes.string,
+      month: PropTypes.string,
+      day: PropTypes.string
     }),
-    date: React.PropTypes.instanceOf(Date).isRequired,
-    maximumDate: React.PropTypes.instanceOf(Date),
-    minimumDate: React.PropTypes.instanceOf(Date),
-    mode: React.PropTypes.oneOf(['date', 'time', 'datetime']),
-    onDateChange: React.PropTypes.func
+    date: PropTypes.instanceOf(Date).isRequired,
+    maximumDate: PropTypes.instanceOf(Date),
+    minimumDate: PropTypes.instanceOf(Date),
+    mode: PropTypes.oneOf(['date', 'time', 'datetime']),
+    onDateChange: PropTypes.func
   }
+
   static defaultProps = {
     labelUnit: { year: '年', month: '月', day: '日' },
     mode: 'date',

--- a/picker.js
+++ b/picker.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import WheelCurvedPicker from './WheelCurvedPicker'
 const PickerItem = WheelCurvedPicker.Item
 import _ from 'lodash'
@@ -26,9 +27,9 @@ export default class Picker extends Component {
   }
 
   static propTypes = {
-    onValueChange: React.PropTypes.func,
-    pickerData: React.PropTypes.array,
-    selectedValue: React.PropTypes.any
+    onValueChange: PropTypes.func,
+    pickerData: PropTypes.array,
+    selectedValue: PropTypes.any
   }
 
   static defaultProps = {


### PR DESCRIPTION
# Overall Notes
I'm issuing this pull request based on a fix I made for this component to get it working on my current application. Basically the PropTypes package was moved for React 15.5+ and it needed to be refactored. I also cleaned up the interface a bit in regards to the native component as it was sharing an interface with the rendered component. The result was that things were a bit out of order and harder to read. This fix was for clarity. 

I also removed the typescript bindings and opted to keep it in ES6 as that seems to be what the rest of the package was using. Hopefully this keeps things clean.

# Bugfix regarding PropTypes
 - Proptypes was refactored into its own package for the current builds of React (15,5 and forward) https://reactjs.org/docs/typechecking-with-proptypes.html
 - This fix specifies an interface for the native component rather than tryign to reuse the PropTypes of the rendering component, additionaly it has been moved to ES6 syntax for clarity with regards to the rest of the package.
# Additional changes
 - there are a couple changes with the ES6 refactoring like binding the _onValue change method and setting up a constructor so the initial state is correct.